### PR TITLE
Add Claude Code commands, fix DMHelper agent, add XML CI validation

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,11 @@
+Run the Northwatch Wardens guide build system.
+
+If the user specified `--players` or `--dms`, pass that flag. Otherwise build both guides.
+
+Steps:
+1. Run `./build.sh $ARGUMENTS` from the repository root and capture output.
+2. Report which output files were produced in `build/` and their sizes.
+3. If the build fails, show the relevant error lines and diagnose the root cause (missing file in TOC JSON, broken markdown syntax, missing npm dependency, etc.).
+4. If warnings appear about missing files, identify which TOC JSON entry is broken and offer to fix it.
+
+Do not open or display the full HTML output — just confirm the files exist and report success or failure.

--- a/.claude/commands/canon-check.md
+++ b/.claude/commands/canon-check.md
@@ -1,0 +1,33 @@
+Check content for canonical consistency with the Northwatch Wardens campaign.
+
+The user will provide a file path, a passage of text, or say "check all" to scan the full repository.
+
+Steps:
+
+1. **Determine scope:**
+   - If a file path is given, read that file.
+   - If text is pasted, analyze it directly.
+   - If "check all" or no argument: scan all `.md` files in `Season 1/` and `World Building/` (excluding `DMEyesOnly/` unless user specifies DM content).
+
+2. **Geography check** — flag any location name that is NOT in the canonical list:
+   - Northreach: Waystone Inn, Welton, Westly's Farm, Shepherd's Crook Inn, Pinebrook, Palebank Village, Croaker Cave, Salsvault, Temple of the Dragonknights, Noke's Tower
+   - Off-map (acceptable references): Solaris, Nullwood/Vaeltharyn, Stonebound Depths/Khardûn-Tharum, Vharoxis, Solace Nexus, Divinity's Beacon
+
+3. **NPC name check** — flag any named NPC that doesn't appear in `Season 1/Campaign Assets/DM Guild Roster.md`. Don't flag generic roles (the innkeeper, a farmer, bandits).
+
+4. **Player-facing content check** (only for files in `build/players-guide-toc.json`):
+   - Flag any markdown file links: `[text](path/file.md)`
+   - Flag any folder/repo references: `` `Premade PCs/` ``, `Season 1/Adventures/`
+   - Flag any GitHub-specific references
+
+5. **Tone check** (optional, only if user asks):
+   - Flag read-aloud text that dictates PC emotions ("you feel scared")
+   - Flag generic fantasy clichés: "ancient evil", "mystical power", "dark forces awakening", "eldritch energies"
+   - Flag overwrought language (more than 3 adjectives per noun)
+
+6. **Report findings** grouped by check type. For each issue:
+   - File and approximate line
+   - The flagged text
+   - Suggested correction
+
+7. **Offer to fix** player-facing link issues automatically (convert file links to chapter references). Ask before making any changes.

--- a/.claude/commands/new-adventure.md
+++ b/.claude/commands/new-adventure.md
@@ -1,0 +1,33 @@
+Scaffold a new adventure for Northwatch Wardens: Season One.
+
+The user will provide: adventure name, level range, setting location, and a brief premise (or ask for suggestions).
+
+Steps:
+
+1. **Confirm canonical fit** — verify the setting location is in the canonical geography table (CLAUDE.md or `.github/copilot-instructions.md`). If a new location is needed, ask the user explicitly before proceeding.
+
+2. **Create the adventure folder and files:**
+   - `Season 1/Adventures/<AdventureName>/` directory
+   - `Season 1/Adventures/<AdventureName>/<AdventureName>.md` — full Homebrewery-formatted adventure guide using the structure from `.github/templates/adventure_template.md`
+   - `Season 1/Adventures/<AdventureName>/<AdventureName>.json` — companion JSON with key NPC and creature stat blocks
+
+3. **Adventure markdown must include:**
+   - Front-matter comment block: `<!-- Tags: Adventure, Season1 / Status: Draft / Type: Adventure -->`
+   - Level range, duration estimate, setting location in the header block
+   - At least 3 adventure hooks
+   - Scenes with `{{descriptive}}` read-aloud blocks and `{{note}}` DM-only blocks
+   - Balancing notes for 2–3 players vs 4–5 players in each combat encounter
+   - At least one Aeorian Echo clue woven in naturally (not announced — show, don't tell)
+   - Conclusion section with success/partial/failure consequences and 2 future hooks
+   - Page breaks (`\page`) with `{{pageNumber,auto}}` / `{{footnote SECTION | ADVENTURE TITLE}}` footers
+
+4. **Tone guidance** (from DMHelper agent):
+   - Grounded frontier realism — tactile, visceral, understated menace
+   - Read-aloud text: 2–4 sentences, sensory-first, end with a hook
+   - Avoid: dictating PC emotions, generic fantasy clichés ("ancient evil"), overwrought tone
+
+5. **Ask the user** if they also want:
+   - An XML `<adventure>` entry added to `LionsdenGameFiles/Northwatch_Wardens.xml`
+   - The adventure added to `build/dms-guide-toc.json`
+
+6. After creating files, show the user the file paths created and remind them to run `/build` to verify it compiles correctly.

--- a/.claude/commands/new-npc.md
+++ b/.claude/commands/new-npc.md
@@ -1,0 +1,31 @@
+Create a new NPC for the Northwatch Wardens campaign.
+
+The user will provide: NPC name, role/concept, and the adventure or location they appear in. Ask for anything missing.
+
+Steps:
+
+1. **Read** `Season 1/Campaign Assets/DM Guild Roster.md` to check for naming conflicts and understand the existing NPC roster style.
+
+2. **Generate the NPC with two representations:**
+
+   **A. Markdown stat block** (Homebrewery `{{monster,frame}}` format for the adventure guide):
+   - Full stat block with STR/DEX/CON/INT/WIS/CHA scores and modifiers
+   - Relevant skills, saves, senses, languages, CR
+   - Traits and Actions with proper attack notation: `+# to hit, XdY+# damage`
+   - A campaign-specific flavor trait that hints at personality or the Aeorian Echo if appropriate
+   - Personality notes block (`{{note}}`) with: speech patterns, mannerisms, what they know, secrets
+
+   **B. XML `<npc>` entry** (Game Master 5e v5 format):
+   - `<uid>` — pick a number not already used in `LionsdenGameFiles/Northwatch_Wardens.xml`
+   - `<enemy>0</enemy>` for allies/neutrals, `<enemy>1</enemy>` for hostiles
+   - All required fields: ac, armor, hpMax, hpCurrent, hd, speed, abilities, passive, languages, cr
+   - `<trait>` and `<action>` elements with `<attack><atk>` and `<dmg>` for all attacks
+   - CDATA for any multi-line text fields
+
+3. **Add to roster** — append the NPC entry to `Season 1/Campaign Assets/DM Guild Roster.md` using the existing format in that file.
+
+4. **Ask the user** whether to also insert the XML entry into `LionsdenGameFiles/Northwatch_Wardens.xml`.
+
+5. **Tone reminder:** Show character through behavior and speech examples, not descriptions. Provide 1–2 example dialogue lines matching their role.
+
+After creating, show the user both representations and the roster entry.

--- a/.claude/commands/session-prep.md
+++ b/.claude/commands/session-prep.md
@@ -1,0 +1,34 @@
+Generate a session prep document for an upcoming Northwatch Wardens session.
+
+The user will provide: which adventure(s) are active, approximate party level, and any notes on what happened last session.
+
+Steps:
+
+1. **Read relevant files:**
+   - The adventure markdown file(s) for the active adventure
+   - `Season 1/DM_Resources/Session_Prep_Guide.md` for the prep format
+   - `Season 1/Campaign Assets/DM Guild Roster.md` for relevant NPCs
+
+2. **Generate a focused one-page session prep document** with these sections:
+
+   **THE SITUATION** (2-3 sentences)
+   Where the party is, what they know, what they don't know yet.
+
+   **3 MOST LIKELY THINGS THAT HAPPEN**
+   Based on the adventure content, predict the 3 most probable player actions and outline how each plays out. Include contingencies.
+
+   **KEY NPCs THIS SESSION**
+   For each relevant NPC: one-line reminder of their voice/mannerism, what they know, what they want.
+
+   **ENCOUNTERS READY TO RUN**
+   For each likely combat: enemy stat summary (AC, HP, key abilities), tactics in 2 sentences, scaling note for small/large party.
+
+   **AEORIAN ECHO MOMENT**
+   One specific, concrete sensory detail the party can encounter that hints at the spreading phenomenon — without explaining it.
+
+   **SESSION END HOOKS**
+   2 options for how to end the session on a compelling note regardless of pacing.
+
+3. Keep the entire document under 2 pages (approximately 600 words). This is a quick-reference tool, not an essay.
+
+4. Ask the user if they want this saved as a file in `Season 1/DM_Resources/` or if it's just for this conversation.

--- a/.claude/commands/validate-xml.md
+++ b/.claude/commands/validate-xml.md
@@ -1,0 +1,36 @@
+Validate Game Master 5e XML files in the Northwatch Wardens campaign.
+
+Steps:
+
+1. **Find all XML files** in the repository (primarily `LionsdenGameFiles/`).
+
+2. **For each XML file, check:**
+
+   **Structure:**
+   - Root element is `<data version="5">` (NOT `<compendium>`)
+   - Campaign uses `<campaign>` as direct child of `<data>`
+   - Adventures nest as: `<adventure> → <encounter> → <combatant> → <monster>`
+   - All `<imageData>` blocks contain `<uniqueID>`
+
+   **Required fields** on every `<npc>` and monster:
+   - `<uid>`, `<label>`, `<ac>`, `<hpMax>`, `<abilities>` (6 comma-separated values), `<cr>`
+   - All `<action>` blocks with attacks must have both `<atk>` AND `<dmg>` inside `<attack>`
+
+   **UID uniqueness:**
+   - Extract all `<uid>` values across the file and report any duplicates
+
+   **CDATA usage:**
+   - Flag any `<text>` fields longer than one line that are NOT wrapped in `<![CDATA[...]]>`
+
+3. **Report findings as a table:**
+
+   | Check | Status | Details |
+   |-------|--------|---------|
+   | Root element | ✅/❌ | ... |
+   | Encounter nesting | ✅/❌ | ... |
+   | Missing required fields | ✅/❌ | List affected elements |
+   | Duplicate UIDs | ✅/❌ | List duplicates |
+   | Incomplete attack blocks | ✅/❌ | List affected actions |
+   | CDATA on long text | ✅/❌ | List affected elements |
+
+4. **If issues found**, offer to fix them automatically. For duplicate UIDs, suggest new unique values. Do not auto-fix without user confirmation.

--- a/.github/agents/DMHelper.agent.md
+++ b/.github/agents/DMHelper.agent.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate and maintain Game Master 5e XML campaign content for Northwatch Wardens: Season One'
-tools: ['vscode', 'execute', 'read', 'edit', 'search', 'web', 'agent', 'dnd/*', 'pylance-mcp-server/*', 'ms-python.python/getPythonEnvironmentInfo', 'ms-python.python/getPythonExecutableCommand', 'ms-python.python/installPythonPackage', 'ms-python.python/configurePythonEnvironment', 'todo']
+tools: ['read', 'edit', 'search', 'web', 'agent', 'dnd/*']
 ---
 
 # Northwatch Wardens — DMHelper Copilot Agent
@@ -31,6 +31,41 @@ This Copilot agent assists with generating, expanding, and maintaining the **Gam
 - Write compelling read-aloud text and NPC dialogue
 - Validate XML structure
 - Convert official D&D stat blocks to Homebrewery format
+
+---
+
+## Standard Workflows
+
+### Creating a New Adventure
+
+1. Confirm setting location is in canonical geography (see table below)
+2. Create `Season 1/Adventures/<Name>/` with:
+   - `<Name>.md` — Homebrewery adventure guide (use `.github/templates/adventure_template.md`)
+   - `<Name>.json` — companion stat block data
+3. Required markdown sections: hooks, scenes with `{{descriptive}}`/`{{note}}` blocks, balancing callouts, Aeorian Echo clue, consequences, future hooks
+4. Add XML `<adventure>` entry to `LionsdenGameFiles/Northwatch_Wardens.xml`
+5. Add to `build/dms-guide-toc.json`
+6. Run `./build.sh --dms` to verify output
+
+### Creating a New NPC
+
+1. Check `Season 1/Campaign Assets/DM Guild Roster.md` for existing names/conflicts
+2. Generate Homebrewery `{{monster,frame}}` stat block + `{{note}}` personality block
+3. Generate XML `<npc>` entry with unique UID (check `Northwatch_Wardens.xml` for highest existing UID)
+4. Append to `DM Guild Roster.md` using the existing format
+5. Insert XML into `Northwatch_Wardens.xml` inside `<campaign>`
+
+### Validating XML
+
+1. Confirm root is `<data version="5">` not `<compendium>`
+2. Check nesting: `campaign > adventure > encounter > combatant > monster`
+3. Verify all `<uid>` values are unique across the file
+4. Confirm all attack `<action>` blocks have both `<atk>` and `<dmg>`
+5. Confirm long `<text>` fields use `<![CDATA[...]]>`
+
+### Querying D&D 5e API (MCP Server)
+
+Use `dnd/*` tools when you need official stat blocks, spell descriptions, or equipment entries. Always adapt official content with campaign-specific flavor rather than copying verbatim. Reference the local MCP config in `.vscode/mcp.json`.
 
 ---
 
@@ -105,12 +140,6 @@ Use these when you explicitly want the wider world beyond Northreach to be “on
 | **Vharoxis** | Southern coast (off-map) | Outlaw city; masks; black-market power | Vharoxis |
 | **Solace Nexus** | Southern valleys (off-map) | Ley-port city; regulated spellwork hub | Verdant Marches |
 | **Divinity's Beacon** | Southern heartlands (off-map) | Multi-faith holy city; oaths; anti-unaccountable magic stance | Solaris Dominion |
-
-## Canonical Geography
-
-**See:** `copilot-instructions.md` for the complete canonical geography tables.
-
-**Key Reminder:** Never invent new Northreach locations. All agent-generated content must use established locations from the main instructions—this ensures consistency with campaign canon.
 
 ---
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,7 +38,26 @@ jobs:
     
     - name: Install dependencies
       run: npm install
-    
+
+    - name: Validate XML files
+      run: |
+        echo "Checking XML well-formedness..."
+        FAIL=0
+        for f in $(find . -name "*.xml" -not -path "./.git/*"); do
+          if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('$f')" 2>/dev/null; then
+            echo "❌ XML parse error in: $f"
+            python3 -c "import xml.etree.ElementTree as ET; ET.parse('$f')"
+            FAIL=1
+          else
+            echo "✅ $f"
+          fi
+        done
+        if [ $FAIL -ne 0 ]; then
+          echo "XML validation failed. Fix errors before building."
+          exit 1
+        fi
+        echo "All XML files valid."
+
     - name: Build guides
       run: ./build.sh
     

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,27 @@ Never invent new locations. All Northreach locations must use these:
 - Full NPC roster: `Season 1/Campaign Assets/DM Guild Roster.md`
 - Tone: grounded low-magic frontier, serious with occasional levity
 
+## Claude Code Slash Commands
+
+Custom commands in `.claude/commands/` are available as `/command-name`:
+
+| Command | Purpose |
+|---------|---------|
+| `/build [--players\|--dms]` | Run the guide build and report output files |
+| `/new-adventure` | Scaffold a new adventure with proper template, structure, and Aeorian Echo integration |
+| `/new-npc` | Generate a new NPC with Homebrewery stat block + XML entry + roster update |
+| `/validate-xml` | Check all XML files for structural errors, duplicate UIDs, missing fields |
+| `/canon-check [file\|text\|"check all"]` | Verify geography, NPC names, player-facing link rules, and tone |
+| `/session-prep` | Generate a focused one-page DM prep document for an upcoming session |
+
 ## Key Reference Files
 
 | File | Purpose |
 |------|---------|
 | `.github/HOMEBREWERY_V3_GUIDE.md` | Complete Homebrewery V3 syntax reference |
 | `.github/copilot-instructions.md` | Detailed coding standards and content guidelines |
-| `.github/agents/DMHelper.agent.md` | DMHelper agent for XML and stat block work |
+| `.github/agents/DMHelper.agent.md` | DMHelper agent for XML, stat blocks, and writing workflows |
+| `.github/templates/adventure_template.md` | Adventure scaffold template |
 | `build/players-guide-toc.json` | Player's guide chapter/file structure |
 | `build/dms-guide-toc.json` | DM's guide chapter/file structure |
 | `Season 1/Campaign Assets/DM Guild Roster.md` | All NPC details and secrets |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Initial guidance file for Claude Code with build commands, architecture overview, canonical geography, and key reference files
- **`.claude/commands/`**: Six slash commands (`/build`, `/new-adventure`, `/new-npc`, `/validate-xml`, `/canon-check`, `/session-prep`) with full campaign-aware workflow steps baked in
- **DMHelper agent**: Removed duplicate Canonical Geography section, fixed tools frontmatter to be platform-agnostic, added Standard Workflows section
- **GitHub Actions**: Added XML well-formedness validation step before build using Python stdlib — fails CI before `./build.sh` if any XML file is malformed

## Test plan

- [ ] Verify `/build` command runs `./build.sh` and reports output files in `build/`
- [ ] Verify `/validate-xml` correctly identifies malformed XML and reports duplicate UIDs
- [ ] Verify `/canon-check` flags non-canonical location names and bad player-facing file links
- [ ] Confirm GitHub Actions XML validation step passes on current XML files
- [ ] Confirm GitHub Actions XML validation step fails if a malformed XML file is introduced

https://claude.ai/code/session_01RQhQCPhS4y17NHSGgcSyY8