### PR TITLE
Fix CI: XML validation fails on filenames with spaces

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         echo "Checking XML well-formedness..."
         FAIL=0
-        for f in $(find . -name "*.xml" -not -path "./.git/*"); do
+        while IFS= read -r -d '' f; do
           if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('$f')" 2>/dev/null; then
             echo "❌ XML parse error in: $f"
             python3 -c "import xml.etree.ElementTree as ET; ET.parse('$f')"
@@ -51,7 +51,7 @@ jobs:
           else
             echo "✅ $f"
           fi
-        done
+        done < <(find . -name "*.xml" -not -path "./.git/*" -not -path "./node_modules/*" -print0)
         if [ $FAIL -ne 0 ]; then
           echo "XML validation failed. Fix errors before building."
           exit 1


### PR DESCRIPTION
## Root Cause

The `Validate XML files` step used:
```bash
for f in $(find . -name "*.xml" ...); do
```

`$(find ...)` word-splits on whitespace, so `LionsdenGameFiles/Northwatch Wardens_ Season One.xml` gets split into four tokens: `./LionsdenGameFiles/Northwatch`, `Wardens_`, `Season`, `One.xml` — each failing with `FileNotFoundError`. This has been the cause of every CI failure since the XML validation step was added.

## Fix

```bash
while IFS= read -r -d '' f; do
  ...
done < <(find . -name "*.xml" -not -path "./.git/*" -not -path "./node_modules/*" -print0)
```

- `-print0` + `read -r -d ''` uses NUL-delimited tokens — handles spaces, newlines, and any special character in filenames
- Added `-not -path "./node_modules/*"` to skip irrelevant node_modules XML files

## Test plan

- [ ] CI build passes on merge to `main`
- [ ] `LionsdenGameFiles/Northwatch Wardens_ Season One.xml` is validated successfully (shows `✅`)
- [ ] All three campaign XML files pass validation

https://claude.ai/code/session_01RQhQCPhS4y17NHSGgcSyY8